### PR TITLE
README updates...

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ With the Dockerfile on repository you've a docker neo4j community edition image 
 
 1. Execute this command:
 
-	`docker run -i -t -d -privileged -p 7474:7474 tpires/neo4j`
+	`docker run -i -t -d --privileged -p 7474:7474 gbenhaim/neo4j`
 
-2. Access to http://localhost:7474 with your browser.
+2. Access to http://localhost:7474 with your browser (or with boot2docker: `open "http://$(boot2docker ip):7474"`).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ With the Dockerfile on repository you've a docker neo4j community edition image 
 
 1. Execute this command:
 
-	`docker run -i -t -d --privileged -p 7474:7474 gbenhaim/neo4j`
+	`docker run -i -t -d --privileged -p 7474:7474 connexiolabs/neo4j`
 
 2. Access to http://localhost:7474 with your browser (or with boot2docker: `open "http://$(boot2docker ip):7474"`).


### PR DESCRIPTION
- Change organization name from tpires to gbenhaim
- -privileged has been deprecated in favor of --privileged
- Added note for opening web interface for those using boot2docker
